### PR TITLE
#99 Fallback method returs value from DB, not default one

### DIFF
--- a/comment-service/src/test/java/kostka/commentservice/CommentServiceTest.java
+++ b/comment-service/src/test/java/kostka/commentservice/CommentServiceTest.java
@@ -42,7 +42,7 @@ public class CommentServiceTest {
 
         Comment result = commentService.createComment(dto);
 
-        assertThat(result).isNotEqualTo(comment);
+        assertThat(result).isEqualTo(comment);
     }
 
     @Test

--- a/src/main/java/kostka/moviecatalog/service/ExternalRatingService.java
+++ b/src/main/java/kostka/moviecatalog/service/ExternalRatingService.java
@@ -20,13 +20,15 @@ import java.util.Objects;
 @Service
 public class ExternalRatingService {
     private RestTemplate restTemplate;
+    private DbMovieService dbMovieService;
     private static final Logger LOGGER = LoggerFactory.getLogger(ExternalRatingService.class);
     private static final String RATING_URL_SERVICE_DISCOVERY = "http://rating-service/rating/";
     private static final String AVERAGE_RATING_URL_SERVICE_DISCOVERY = "http://rating-service/rating/average/";
 
     @Autowired
-    public ExternalRatingService(final RestTemplate restTemplate) {
+    public ExternalRatingService(final RestTemplate restTemplate, final DbMovieService dbMovieService) {
         this.restTemplate = restTemplate;
+        this.dbMovieService = dbMovieService;
     }
 
     /**
@@ -80,7 +82,7 @@ public class ExternalRatingService {
      * @return default value of the average rating.
      */
     public double getAverageRatingFromRatingServiceFallback(final Long movieId) {
-        LOGGER.info("Rating Service is down - return default average Rating.");
-        return movieId;
+        LOGGER.info("Rating Service is down - return the stored value in DB for average Rating.");
+        return dbMovieService.getMovie(movieId).getAverageRating();
     }
 }

--- a/src/main/resources/templates/detail.html
+++ b/src/main/resources/templates/detail.html
@@ -14,7 +14,7 @@
     </p>
     <p class="text">Description: <span th:text="${movieDetail.description}"></span>
     </p>
-    <p class="text">Rating: <span th:text="${movieDetail.averageRating}"></span>
+    <p class="text">Calculated Average Rating: <span th:text="${movieDetail.averageRating}"></span>
     </p>
     <div class="container">
         <table class="table">


### PR DESCRIPTION
When the average value was already calculated and then the microservice was down. fallback method saves the default value to average rating.

This fix will improve the fallback method to return the average rating which is already calculated and stored in db.

Closes #99 