### PR TITLE
Bugfix - when microservices went down, user ID was default and hence …

### DIFF
--- a/src/main/java/kostka/moviecatalog/service/ExternalCommentService.java
+++ b/src/main/java/kostka/moviecatalog/service/ExternalCommentService.java
@@ -19,7 +19,7 @@ import java.util.Objects;
  */
 @Service
 public class ExternalCommentService {
-    public static final long DEFAULT_ID = 999L;
+    public static final long DEFAULT_ID = 201L;
     private static final Logger LOGGER = LoggerFactory.getLogger(ExternalCommentService.class);
     private static final String COMMENT_SERVICE_URL = "http://comment-service/comments/";
     private static final String GET_LATEST5 = "latest5";
@@ -43,9 +43,8 @@ public class ExternalCommentService {
     }
 
     public List<Comment> getCommentsFromCommentServiceFallback(final Long movieId) {
-        LOGGER.warn("Comment service is down - return default list of comments.");
-        Comment defaultComment = getDefaultComment(movieId);
-        return Collections.singletonList(defaultComment);
+        LOGGER.warn("Comment service is down - return empty list of comments.");
+        return Collections.emptyList();
     }
 
     @HystrixCommand(fallbackMethod = "createCommentInCommentServiceFallback")

--- a/src/main/java/kostka/moviecatalog/service/ExternalRatingService.java
+++ b/src/main/java/kostka/moviecatalog/service/ExternalRatingService.java
@@ -15,8 +15,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-import static kostka.moviecatalog.service.ExternalCommentService.DEFAULT_ID;
-
 /**
  * Service which communicates with external microservice (RatingService) via rest template.
  */
@@ -73,13 +71,8 @@ public class ExternalRatingService {
      * @return default list of one rating with default values.
      */
     public List<Rating> getRatingsFromRatingServiceFallback(final Long movieId) {
-        LOGGER.info("Rating Service is down - return default rating List.");
-        Rating randomRating = new Rating();
-        randomRating.setMovieId(movieId);
-        randomRating.setRatingId(DEFAULT_ID);
-        randomRating.setRatingValue(0);
-        randomRating.setAuthorId(DEFAULT_ID);
-        return Collections.singletonList(randomRating);
+        LOGGER.info("Rating Service is down - return empty rating List.");
+        return Collections.emptyList();
     }
 
     /**

--- a/src/main/java/kostka/moviecatalog/service/ExternalShopService.java
+++ b/src/main/java/kostka/moviecatalog/service/ExternalShopService.java
@@ -82,10 +82,7 @@ public class ExternalShopService {
     }
 
     public List<MovieListDto> getAlreadyBoughtMoviesForUserFallback(final Long userId) {
-        MovieListDto movieList = new MovieListDto();
-        movieList.setId(DEFAULT_ID);
-        movieList.setDescription("Shop Service is down");
-        return Collections.singletonList(movieList);
+        return Collections.emptyList();
     }
 
     @HystrixCommand(fallbackMethod = "checkAlreadyBoughtMovieForUserFallback")


### PR DESCRIPTION
currently when any microservice is down, e.g. comment service .. it returns default comment with default user id.
later when the user is searched in DB with the default id, exception is thrown

so I used admin ID instead of default ID .. 